### PR TITLE
Feat: party 생성 및 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/sesac/joinflex/domain/party/controller/ExClass.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/controller/ExClass.java
@@ -1,5 +1,0 @@
-package com.sesac.joinflex.domain.party.controller;
-
-public class ExClass {
-
-}

--- a/src/main/java/com/sesac/joinflex/domain/party/controller/PartyController.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/controller/PartyController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/partys")
+@RequestMapping("/api/parties")
 @RequiredArgsConstructor
 public class PartyController {
 

--- a/src/main/java/com/sesac/joinflex/domain/party/controller/PartyController.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/controller/PartyController.java
@@ -1,14 +1,20 @@
 package com.sesac.joinflex.domain.party.controller;
 
 import com.sesac.joinflex.domain.party.dto.request.PartyRoomRequest;
+import com.sesac.joinflex.domain.party.dto.response.PartyRoomResponse;
 import com.sesac.joinflex.domain.party.service.PartyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,4 +31,10 @@ public class PartyController {
             .body(partyService.createPartyRoom(request, 1L));
     }
 
+    @GetMapping
+    public ResponseEntity<Slice<PartyRoomResponse>> getPartyRooms(
+        @RequestParam(required = false) Long cursorId,
+        @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(partyService.getPartyRooms(cursorId, pageable));
+    }
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/controller/PartyController.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/controller/PartyController.java
@@ -1,0 +1,28 @@
+package com.sesac.joinflex.domain.party.controller;
+
+import com.sesac.joinflex.domain.party.dto.request.PartyRoomRequest;
+import com.sesac.joinflex.domain.party.service.PartyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/partys")
+@RequiredArgsConstructor
+public class PartyController {
+
+    private final PartyService partyService;
+
+    @PostMapping
+    public ResponseEntity<Long> createPartyRoom(@Valid @RequestBody PartyRoomRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            // Todo security 구현 후 수정 예정
+            .body(partyService.createPartyRoom(request, 1L));
+    }
+
+}

--- a/src/main/java/com/sesac/joinflex/domain/party/dto/request/ExClass.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/dto/request/ExClass.java
@@ -1,5 +1,0 @@
-package com.sesac.joinflex.domain.party.dto.request;
-
-public class ExClass {
-
-}

--- a/src/main/java/com/sesac/joinflex/domain/party/dto/request/PartyRoomRequest.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/dto/request/PartyRoomRequest.java
@@ -1,0 +1,36 @@
+package com.sesac.joinflex.domain.party.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record PartyRoomRequest(
+
+    @NotNull(message = "movieId는 필수입니다.")
+    @Positive(message = "movieId는 양수여야 합니다.")
+    Long movieId,
+
+    @Size(min = 1, max = 20, message = "roomName은 1~20자만 입력 가능합니다.")
+    @NotBlank(message = "roomName은 필수입니다.")
+    String roomName,
+
+    @NotNull(message = "isPublic은 필수입니다.")
+    Boolean isPublic,
+
+    @NotNull(message = "hostControl은 필수입니다.")
+    Boolean hostControl,
+
+    @Size(min = 4, max = 4, message = "passCode 숫자 4자만 입력 가능합니다.")
+    @Pattern(regexp = "\\d{4}")
+    String passCode,
+
+    List<Long> invitedUserIds
+) {
+
+    public PartyRoomRequest {
+        invitedUserIds = (invitedUserIds == null) ? List.of() : List.copyOf(invitedUserIds);
+    }
+}

--- a/src/main/java/com/sesac/joinflex/domain/party/dto/request/PartyRoomRequest.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/dto/request/PartyRoomRequest.java
@@ -1,5 +1,6 @@
 package com.sesac.joinflex.domain.party.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -32,5 +33,14 @@ public record PartyRoomRequest(
 
     public PartyRoomRequest {
         invitedUserIds = (invitedUserIds == null) ? List.of() : List.copyOf(invitedUserIds);
+    }
+
+    @AssertTrue(message = "비공개 방은 비밀번호(passCode)가 필수입니다.")
+    private boolean isPassCodeValid() {
+        if (Boolean.TRUE.equals(isPublic)) {
+            return true;
+        }
+
+        return passCode != null && !passCode.isBlank();
     }
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/dto/response/ExClass.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/dto/response/ExClass.java
@@ -1,5 +1,0 @@
-package com.sesac.joinflex.domain.party.dto.response;
-
-public class ExClass {
-
-}

--- a/src/main/java/com/sesac/joinflex/domain/party/dto/response/PartyRoomResponse.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/dto/response/PartyRoomResponse.java
@@ -1,0 +1,11 @@
+package com.sesac.joinflex.domain.party.dto.response;
+
+public record PartyRoomResponse(
+    Long id,
+    String movieTitle,
+    String roomName,
+    String hostNickname,
+    Integer currentMemberCount
+) {
+
+}

--- a/src/main/java/com/sesac/joinflex/domain/party/entity/InviteStatus.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/entity/InviteStatus.java
@@ -1,0 +1,6 @@
+package com.sesac.joinflex.domain.party.entity;
+
+public enum InviteStatus {
+    PENDING,
+    JOINED
+}

--- a/src/main/java/com/sesac/joinflex/domain/party/entity/PartyInvite.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/entity/PartyInvite.java
@@ -32,4 +32,13 @@ public class PartyInvite extends BaseEntity {
     @JoinColumn(name = "guest_id", nullable = false)
     private User guest;
 
+    private PartyInvite(PartyRoom partyRoom, User guest) {
+        this.partyRoom = partyRoom;
+        this.guest = guest;
+    }
+
+    public static PartyInvite create(PartyRoom partyRoom, User guest) {
+        return new PartyInvite(partyRoom, guest);
+    }
+
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/entity/PartyInvite.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/entity/PartyInvite.java
@@ -3,6 +3,8 @@ package com.sesac.joinflex.domain.party.entity;
 import com.sesac.joinflex.domain.user.entity.User;
 import com.sesac.joinflex.global.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,13 +34,17 @@ public class PartyInvite extends BaseEntity {
     @JoinColumn(name = "guest_id", nullable = false)
     private User guest;
 
-    private PartyInvite(PartyRoom partyRoom, User guest) {
+    @Enumerated(EnumType.STRING)
+    private InviteStatus status;
+
+    private PartyInvite(PartyRoom partyRoom, User guest, InviteStatus status) {
         this.partyRoom = partyRoom;
         this.guest = guest;
+        this.status = status;
     }
 
     public static PartyInvite create(PartyRoom partyRoom, User guest) {
-        return new PartyInvite(partyRoom, guest);
+        return new PartyInvite(partyRoom, guest, InviteStatus.PENDING);
     }
 
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/entity/PartyRoom.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/entity/PartyRoom.java
@@ -3,6 +3,7 @@ package com.sesac.joinflex.domain.party.entity;
 import com.sesac.joinflex.domain.movie.entity.Movie;
 import com.sesac.joinflex.domain.user.entity.User;
 import com.sesac.joinflex.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -33,8 +34,16 @@ public class PartyRoom extends BaseEntity {
     @JoinColumn(name = "movie_id", nullable = false)
     private Movie movie;
 
-    // 공개 / 비공개 여부
+    @Column(nullable = false)
+    private String roomName;
 
-    // 비밀번호
+    @Column(nullable = false)
+    private Boolean isPublic;
+
+    @Column(nullable = false)
+    private Boolean hostControl;
+
+    private String passCode;
+
 
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/entity/PartyRoom.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/entity/PartyRoom.java
@@ -45,5 +45,22 @@ public class PartyRoom extends BaseEntity {
 
     private String passCode;
 
+    private PartyRoom(String roomName, User host, Movie movie, Boolean isPublic,
+        Boolean hostControl, String passCode) {
+        this.roomName = roomName;
+        this.host = host;
+        this.movie = movie;
+        this.isPublic = isPublic;
+        this.hostControl = hostControl;
+        this.passCode = passCode;
+    }
+
+    public static PartyRoom create(String roomName, User host, Movie movie, Boolean isPublic, Boolean hostControl, String passCode) {
+        if (isPublic) {
+            return new PartyRoom(roomName, host, movie, true, true, null);
+        } else {
+            return new PartyRoom(roomName, host, movie, false, hostControl, passCode);
+        }
+    }
 
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/entity/PartyRoom.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/entity/PartyRoom.java
@@ -45,6 +45,8 @@ public class PartyRoom extends BaseEntity {
 
     private String passCode;
 
+    private Integer currentMemberCount;
+
     private PartyRoom(String roomName, User host, Movie movie, Boolean isPublic,
         Boolean hostControl, String passCode) {
         this.roomName = roomName;
@@ -53,6 +55,7 @@ public class PartyRoom extends BaseEntity {
         this.isPublic = isPublic;
         this.hostControl = hostControl;
         this.passCode = passCode;
+        this.currentMemberCount = 0;
     }
 
     public static PartyRoom create(String roomName, User host, Movie movie, Boolean isPublic, Boolean hostControl, String passCode) {

--- a/src/main/java/com/sesac/joinflex/domain/party/repository/PartyRoomRepository.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/repository/PartyRoomRepository.java
@@ -1,10 +1,22 @@
 package com.sesac.joinflex.domain.party.repository;
 
 import com.sesac.joinflex.domain.party.entity.PartyRoom;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
 
+    @Query(
+        """
+              select pr from PartyRoom pr
+              where pr.id < :cursorId
+              order by pr.id desc
+            """
+    )
+    Slice<PartyRoom> findPartyRooms(@Param("cursorId") Long cursorId, Pageable pageable);
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/repository/PartyRoomRepository.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/repository/PartyRoomRepository.java
@@ -14,6 +14,8 @@ public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
     @Query(
         """
               select pr from PartyRoom pr
+              join fetch pr.movie
+              join fetch pr.host
               where pr.id < :cursorId
               order by pr.id desc
             """

--- a/src/main/java/com/sesac/joinflex/domain/party/service/ExClass.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/ExClass.java
@@ -1,5 +1,0 @@
-package com.sesac.joinflex.domain.party.service;
-
-public class ExClass {
-
-}

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyInviteService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyInviteService.java
@@ -1,0 +1,56 @@
+package com.sesac.joinflex.domain.party.service;
+
+import com.sesac.joinflex.domain.party.entity.PartyInvite;
+import com.sesac.joinflex.domain.party.entity.PartyRoom;
+import com.sesac.joinflex.domain.party.repository.PartyInviteRepository;
+import com.sesac.joinflex.domain.user.entity.User;
+import com.sesac.joinflex.domain.user.repository.UserRepository;
+import com.sesac.joinflex.global.infra.mail.EmailService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartyInviteService {
+
+    private final String DOMAIN_URL = "http://localhost:8080";
+
+    private final PartyInviteRepository partyInviteRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+
+    public void inviteUsers(PartyRoom room, List<Long> userIds) {
+        List<User> guests = userRepository.findAllById(userIds);
+
+        if (guests.size() != userIds.size()) {
+            throw new IllegalArgumentException("존재하지 않는 사용자가 포함되어 있습니다.");
+        }
+
+        for (User guest : guests) {
+            partyInviteRepository.save(PartyInvite.create(room, guest));
+            // 이메일 발송
+            sendInviteEmail(guest, room);
+        }
+    }
+
+    private void sendInviteEmail(User guest, PartyRoom room) {
+        String subject = "[JoinFlex] 파티 초대장이 도착했습니다!";
+
+        String joinUrl = String.format("%s/parties/%d", DOMAIN_URL, room.getId());
+
+        String message = String.format("""
+                %s님이 '%s' 파티에 초대했습니다.
+                링크를 클릭해서 입장하세요: %s
+                """,
+            room.getHost().getNickname(),
+            room.getRoomName(),
+            joinUrl);
+
+        emailService.sendEmail(guest.getEmail(), subject, message);
+    }
+
+}

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyInviteService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyInviteService.java
@@ -23,11 +23,11 @@ public class PartyInviteService {
     private final EmailService emailService;
 
 
-    public void inviteUsers(PartyRoom room, List<Long> userIds) {
-        List<User> guests = userRepository.findAllById(userIds);
+    public void inviteUsers(PartyRoom room, User host, List<Long> userIds) {
+        List<User> guests = userRepository.findFriendsByHostAndIds(host, userIds);
 
         if (guests.size() != userIds.size()) {
-            throw new IllegalArgumentException("존재하지 않는 사용자가 포함되어 있습니다.");
+            throw new IllegalArgumentException("친구 관계가 아니거나 존재하지 않는 사용자가 포함되어 있습니다.");
         }
 
         for (User guest : guests) {

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
@@ -7,7 +7,6 @@ import com.sesac.joinflex.domain.party.entity.PartyRoom;
 import com.sesac.joinflex.domain.party.repository.PartyRoomRepository;
 import com.sesac.joinflex.domain.user.entity.User;
 import com.sesac.joinflex.domain.user.repository.UserRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,7 @@ public class PartyService {
     private final PartyInviteService partyInviteService;
 
     @Transactional
-    public Long createPartyRoom(@Valid PartyRoomRequest request, Long userId) {
+    public Long createPartyRoom(PartyRoomRequest request, Long userId) {
         Movie movie = movieRepository.findById(request.movieId())
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화입니다."));
 

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
@@ -3,11 +3,14 @@ package com.sesac.joinflex.domain.party.service;
 import com.sesac.joinflex.domain.movie.entity.Movie;
 import com.sesac.joinflex.domain.movie.repository.MovieRepository;
 import com.sesac.joinflex.domain.party.dto.request.PartyRoomRequest;
+import com.sesac.joinflex.domain.party.dto.response.PartyRoomResponse;
 import com.sesac.joinflex.domain.party.entity.PartyRoom;
 import com.sesac.joinflex.domain.party.repository.PartyRoomRepository;
 import com.sesac.joinflex.domain.user.entity.User;
 import com.sesac.joinflex.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,4 +46,18 @@ public class PartyService {
         return savedRoom.getId();
     }
 
+
+    public Slice<PartyRoomResponse> getPartyRooms(Long cursorId, Pageable pageable) {
+
+        Slice<PartyRoom> rooms = partyRoomRepository.findPartyRooms(
+            cursorId == null ? Long.MAX_VALUE : cursorId, pageable);
+
+        return rooms.map(room -> new PartyRoomResponse(
+            room.getId(),
+            room.getMovie().getTitle(),
+            room.getRoomName(),
+            room.getHost().getNickname(),
+            room.getCurrentMemberCount()
+        ));
+    }
 }

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
@@ -39,7 +39,7 @@ public class PartyService {
                 request.passCode()));
 
         // 친구 초대
-        partyInviteService.inviteUsers(savedRoom, request.invitedUserIds());
+        partyInviteService.inviteUsers(savedRoom, host, request.invitedUserIds());
 
         return savedRoom.getId();
     }

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
@@ -1,0 +1,43 @@
+package com.sesac.joinflex.domain.party.service;
+
+import com.sesac.joinflex.domain.movie.entity.Movie;
+import com.sesac.joinflex.domain.movie.repository.MovieRepository;
+import com.sesac.joinflex.domain.party.dto.request.PartyRoomRequest;
+import com.sesac.joinflex.domain.party.entity.PartyRoom;
+import com.sesac.joinflex.domain.party.repository.PartyRoomRepository;
+import com.sesac.joinflex.domain.user.entity.User;
+import com.sesac.joinflex.domain.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartyService {
+
+    private final PartyRoomRepository partyRoomRepository;
+    private final MovieRepository movieRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long createPartyRoom(@Valid PartyRoomRequest request, Long userId) {
+        Movie movie = movieRepository.findById(request.movieId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화입니다."));
+
+        // Todo security 구현 시 제거 예정
+        User host = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // Todo membership 검증 예정 (결제한 사람만 파티 생성 가능)
+
+        PartyRoom savedRoom = partyRoomRepository.save(
+            PartyRoom.create(request.roomName(), host, movie, request.isPublic(),
+                request.hostControl(),
+                request.passCode()));
+
+        return savedRoom.getId();
+    }
+
+}

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyService.java
@@ -20,6 +20,7 @@ public class PartyService {
     private final PartyRoomRepository partyRoomRepository;
     private final MovieRepository movieRepository;
     private final UserRepository userRepository;
+    private final PartyInviteService partyInviteService;
 
     @Transactional
     public Long createPartyRoom(@Valid PartyRoomRequest request, Long userId) {
@@ -36,6 +37,9 @@ public class PartyService {
             PartyRoom.create(request.roomName(), host, movie, request.isPublic(),
                 request.hostControl(),
                 request.passCode()));
+
+        // 친구 초대
+        partyInviteService.inviteUsers(savedRoom, request.invitedUserIds());
 
         return savedRoom.getId();
     }

--- a/src/main/java/com/sesac/joinflex/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sesac/joinflex/domain/user/repository/UserRepository.java
@@ -1,10 +1,26 @@
 package com.sesac.joinflex.domain.user.repository;
 
 import com.sesac.joinflex.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    @Query(
+        """
+                 select u from User u
+                 where u.id in :userIds
+                 and exists (select 1 from FriendRequest fr
+                             where fr.isAccepted = true
+                             and fr.sender = :host and fr.receiver = u
+                             or fr.receiver = :host and fr.sender = u
+                            )
+            """
+    )
+    List<User> findFriendsByHostAndIds(@Param("host") User host,
+        @Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/sesac/joinflex/global/infra/mail/EmailService.java
+++ b/src/main/java/com/sesac/joinflex/global/infra/mail/EmailService.java
@@ -1,0 +1,6 @@
+package com.sesac.joinflex.global.infra.mail;
+
+public interface EmailService {
+
+    void sendEmail(String to, String subject, String text);
+}

--- a/src/main/java/com/sesac/joinflex/global/infra/mail/SmtpEmailService.java
+++ b/src/main/java/com/sesac/joinflex/global/infra/mail/SmtpEmailService.java
@@ -1,0 +1,26 @@
+package com.sesac.joinflex.global.infra.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SmtpEmailService implements EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void sendEmail(String to, String subject, String text) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(text);
+            javaMailSender.send(message);
+        } catch (Exception e) {
+            throw new RuntimeException("메일 발송 실패");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,20 @@
         enabled: ${DEVTOOLS_RESTART:true}
       livereload:
         enabled: ${DEVTOOLS_LIVERELOAD:true}
+    mail:
+      host: smtp.gmail.com
+      port: 587
+      username: ${GOOGLE_USERNAME}@gmail.com
+      password: ${GOOGLE_MAIL_PASSWORD}
+      properties:
+        mail:
+          smtp:
+            auth: true
+            starttls:
+              enable: true
+
+      default-encoding: UTF-8
+
 
   #actuator
   management:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,13 +28,13 @@ VALUES ('범죄도시4', NOW(), NOW()),
        ('파묘', NOW(), NOW());
 
 -- 4. 파티방 (Party Rooms)
-INSERT INTO party_rooms (host_id, movie_id, room_name, is_public, host_control, created_at, updated_at)
-VALUES (1, 1, '흥미진진', false, true, NOW(), NOW()), -- ID 1: 김철수 방
-       (2, 3, '재밌겠다', false, true, NOW(), NOW()), -- ID 2: 이영희 방
-       (5, 5, '같이 영화봐요', false, true, NOW(), NOW()); -- ID 3: 정우성 방
+INSERT INTO party_rooms (host_id, movie_id, room_name, is_public, host_control, current_member_count, created_at, updated_at)
+VALUES (1, 1, '흥미진진', false, true, 2, NOW(), NOW()), -- ID 1: 김철수 방
+       (2, 3, '재밌겠다', false, true, 2, NOW(), NOW()), -- ID 2: 이영희 방
+       (5, 5, '같이 영화봐요', false, true, 2,NOW(), NOW()); -- ID 3: 정우성 방
 
 -- 5. 파티 초대 (Party Invites)
-INSERT INTO party_invites (party_room_id, guest_id, created_at, updated_at)
-VALUES (1, 2, NOW(), NOW()),
-       (2, 3, NOW(), NOW()),
-       (3, 1, NOW(), NOW());
+INSERT INTO party_invites (party_room_id, guest_id, status, created_at, updated_at)
+VALUES (1, 2, 'JOINED', NOW(), NOW()),
+       (2, 3, 'JOINED', NOW(), NOW()),
+       (3, 1, 'JOINED', NOW(), NOW());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,10 +28,10 @@ VALUES ('범죄도시4', NOW(), NOW()),
        ('파묘', NOW(), NOW());
 
 -- 4. 파티방 (Party Rooms)
-INSERT INTO party_rooms (host_id, movie_id, created_at, updated_at)
-VALUES (1, 1, NOW(), NOW()), -- ID 1: 김철수 방
-       (2, 3, NOW(), NOW()), -- ID 2: 이영희 방
-       (5, 5, NOW(), NOW()); -- ID 3: 정우성 방
+INSERT INTO party_rooms (host_id, movie_id, room_name, is_public, host_control, created_at, updated_at)
+VALUES (1, 1, '흥미진진', false, true, NOW(), NOW()), -- ID 1: 김철수 방
+       (2, 3, '재밌겠다', false, true, NOW(), NOW()), -- ID 2: 이영희 방
+       (5, 5, '같이 영화봐요', false, true, NOW(), NOW()); -- ID 3: 정우성 방
 
 -- 5. 파티 초대 (Party Invites)
 INSERT INTO party_invites (party_room_id, guest_id, created_at, updated_at)


### PR DESCRIPTION
## 작업 내용
* 특정 영화에 대한 파티 생성 기능 구현
  * 공개 / 비공개 선택 가능 - 비공개인 경우 passCode 입력 필수
  * 조작 선택 가능 (방장만 / 누구나) - 공개인 경우 방장만 조작 가능
* 친구 초대 / 이메일 초대 링크 발송
  * 친구만 초대 가능
* 파티 전체 조회 기능 구현

## 참고 사항
* `security` 구현 시 직접 작성한 userId 수정할 예정
* `membership` 구현 시 해당 사용자의 `membership` 검증 추가할 예정
* 파티 참가 여부 확인을 위해 `PartyInvite`에 status 추가
* 파티 참가 인원 가져오기가 번거로워서 `PartyRoom`에 `currentMemberCount` 추가 (입/퇴장 시 증감 예정)
* 아직 알림은 따로 구현하지 않은 상태

## API 명세서
* [파티 생성](https://www.notion.so/holdrainnotere47/API-2ef951ddbec3808e811af6f7c225b33b?p=2ef951ddbec3809bb5a5ff8dfc5f3e8c&pm=s)
* [파티 전체 조회](https://www.notion.so/holdrainnotere47/API-2ef951ddbec3808e811af6f7c225b33b?p=2ef951ddbec380ec9d5ce76acf8b01ff&pm=s)