### PR TITLE
feat: notification 엔티티 생성

### DIFF
--- a/src/main/java/com/sesac/joinflex/domain/notification/dto/response/NotificationEventResponse.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/dto/response/NotificationEventResponse.java
@@ -1,0 +1,13 @@
+package com.sesac.joinflex.domain.notification.dto.response;
+
+import com.sesac.joinflex.domain.notification.type.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationEventResponse {
+    private NotificationType type;
+    private String message;
+    private Long targetId;
+}

--- a/src/main/java/com/sesac/joinflex/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,30 @@
+package com.sesac.joinflex.domain.notification.dto.response;
+
+import com.sesac.joinflex.domain.notification.entity.Notification;
+import com.sesac.joinflex.domain.notification.type.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NotificationResponse {
+    private Long id;
+    private NotificationType type;
+    private String message;
+    private Boolean isRead;
+    private Long targetId;
+    private LocalDateTime createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+            .id(notification.getId())
+            .type(notification.getType())
+            .message(notification.getMessage())
+            .isRead(notification.getIsRead())
+            .targetId(notification.getTargetId())
+            .createdAt(notification.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/sesac/joinflex/domain/notification/entity/Notification.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/entity/Notification.java
@@ -1,0 +1,51 @@
+package com.sesac.joinflex.domain.notification.entity;
+
+import com.sesac.joinflex.domain.notification.type.NotificationType;
+import com.sesac.joinflex.domain.user.entity.User;
+import com.sesac.joinflex.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notifications")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    private Long targetId;
+    
+    @Builder
+    private Notification(User user, NotificationType type, String message, Long targetId){
+        this.user = user;
+        this.type = type;
+        this.message = message;
+        this.targetId = targetId;
+        this.isRead = false;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+}

--- a/src/main/java/com/sesac/joinflex/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.sesac.joinflex.domain.notification.repository;
+
+import com.sesac.joinflex.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}


### PR DESCRIPTION
## [구현한 내용]
notification 엔티티를 생성
- 알림(친구신청, 파티초대)서비스 데이터 처리를 위해 notification 엔티티를 생성하였습니다.


close #40 