### PR TITLE
fix: 데이터베이스 시간대를 Asia/Seoul로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@
       ansi:
         enabled: ${ANSI_ENABLED:always}
     datasource:
-      url: ${DATABASE_URL:jdbc:mysql://localhost:3306/joinflix?useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC}
+      url: ${DATABASE_URL:jdbc:mysql://localhost:3306/joinflix?useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}
       username: ${DB_USERNAME:root}
       password: ${DB_PASSWORD:password}
     jpa:
@@ -23,6 +23,7 @@
       properties:
         hibernate:
           dialect: org.hibernate.dialect.MySQLDialect
+          jdbc.time_zone: Asia/Seoul
           format_sql: ${JPA_FORMAT_SQL:true}
           use_sql_comments: ${JPA_SQL_COMMENTS:true}
           generate_statistics: ${JPA_STATISTICS:true}


### PR DESCRIPTION
## [변경한 내용]
application.yml 파일에서 데이터베이스 시간대를 Asia/Seoul로 변경
> 데이터 생성시 생성 시간과, 데이터베이스에 저장되는 데이터 시간이 불일치하는 문제 해결을 위해


close #47 