### PR TITLE
refactor: 알림 일괄 읽음 처리

### DIFF
--- a/src/main/java/com/sesac/joinflex/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/controller/NotificationController.java
@@ -1,12 +1,12 @@
 package com.sesac.joinflex.domain.notification.controller;
 
+import com.sesac.joinflex.domain.notification.dto.request.NotificationReadRequest;
 import com.sesac.joinflex.domain.notification.service.NotificationService;
 import com.sesac.joinflex.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -20,5 +20,13 @@ public class NotificationController {
     public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return notificationService.subscribe(customUserDetails.getId());
     }
-
+    // POST http://localhost:8080/api/notifications/last-read-at
+    @PostMapping("/last-read-at")
+    public ResponseEntity<Void> readNotification(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody NotificationReadRequest request
+    ) {
+        notificationService.updateLastNotificationReadAt(customUserDetails.getId(), request.getClickedAt());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sesac/joinflex/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/controller/NotificationController.java
@@ -22,7 +22,7 @@ public class NotificationController {
     }
     // POST http://localhost:8080/api/notifications/last-read-at
     @PostMapping("/last-read-at")
-    public ResponseEntity<Void> readNotification(
+    public ResponseEntity<Void> updateLastReadTimestamp(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody NotificationReadRequest request
     ) {

--- a/src/main/java/com/sesac/joinflex/domain/notification/dto/request/NotificationReadRequest.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/dto/request/NotificationReadRequest.java
@@ -1,0 +1,14 @@
+package com.sesac.joinflex.domain.notification.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NotificationReadRequest {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime clickedAt;
+}

--- a/src/main/java/com/sesac/joinflex/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.sesac.joinflex.domain.notification.repository;
 
 import com.sesac.joinflex.domain.notification.entity.Notification;
 import com.sesac.joinflex.domain.user.entity.User;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +12,5 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByUser(User user);
+    List<Notification> findByUserAndCreatedAtAfter(User user, LocalDateTime createdAt);
 }

--- a/src/main/java/com/sesac/joinflex/domain/user/entity/User.java
+++ b/src/main/java/com/sesac/joinflex/domain/user/entity/User.java
@@ -57,6 +57,9 @@ public class User extends BaseEntity {
     @Column(name = "membership_expiry_date")
     private LocalDateTime membershipExpiryDate;
 
+    @Column(name = "last_notification_read_at")
+    private LocalDateTime lastNotificationReadAt;
+
     @Builder
     private User(String email, String password, String nickname, String signupIp,
                  Boolean isLock, Boolean isSocial, SocialProviderType socialProviderType,
@@ -71,6 +74,7 @@ public class User extends BaseEntity {
         this.isOnline = (isOnline != null) ? isOnline : false;
         this.socialProviderType = socialProviderType;
         this.profileImageUrl = profileImageUrl;
+        this.lastNotificationReadAt = LocalDateTime.now();  // 가입 시점으로 초기화
     }
 
     // 로그인 시 호출할 메서드
@@ -128,5 +132,10 @@ public class User extends BaseEntity {
     // 계정 잠금 해제
     public void unlockAccount() {
         this.isLock = false;
+    }
+    
+    //알림 읽음 상태 업데이트
+    public void updateLastNotificationReadAt(LocalDateTime clickedAt) {
+        this.lastNotificationReadAt = clickedAt;
     }
 }

--- a/src/main/java/com/sesac/joinflex/domain/user/entity/User.java
+++ b/src/main/java/com/sesac/joinflex/domain/user/entity/User.java
@@ -74,7 +74,7 @@ public class User extends BaseEntity {
         this.isOnline = (isOnline != null) ? isOnline : false;
         this.socialProviderType = socialProviderType;
         this.profileImageUrl = profileImageUrl;
-        this.lastNotificationReadAt = LocalDateTime.now();  // 가입 시점으로 초기화
+        this.lastNotificationReadAt = null;
     }
 
     // 로그인 시 호출할 메서드

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,12 +10,12 @@ VALUES ('FREE', '무료 체험', '기본적인 서비스 탐색이 가능한 무
 -- 비밀번호: 'test1234' (BCrypt 암호화)
 -- 멤버십 ID 1번(FREE)을 기본 할당한다고 가정
 INSERT INTO users (email, password, nickname, signup_ip, role_type, is_social, is_lock, is_online, membership_id, last_notification_read_at, created_at, updated_at)
-VALUES ('test@test.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', 'test', '127.0.0.1', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
-       ('kim@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '김철수', '127.0.0.2', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
-       ('lee@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '이영희', '127.0.0.3', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
-       ('park@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '박민수', '127.0.0.4', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
-       ('choi@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '최지은', '127.0.0.5', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
-       ('jung@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '정우성', '127.0.0.6', 'USER', false, false, false, 1,  NOW(), NOW(), NOW());
+VALUES ('test@test.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', 'test', '127.0.0.1', 'USER', false, false, false, 1,  null, NOW(), NOW()),
+       ('kim@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '김철수', '127.0.0.2', 'USER', false, false, false, 1,  null, NOW(), NOW()),
+       ('lee@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '이영희', '127.0.0.3', 'USER', false, false, false, 1,  null, NOW(), NOW()),
+       ('park@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '박민수', '127.0.0.4', 'USER', false, false, false, 1,  null, NOW(), NOW()),
+       ('choi@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '최지은', '127.0.0.5', 'USER', false, false, false, 1,  null, NOW(), NOW()),
+       ('jung@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '정우성', '127.0.0.6', 'USER', false, false, false, 1,  null, NOW(), NOW());
 
 -- 3. 친구 요청 (Friend Requests)
 INSERT INTO friend_requests (sender_id, receiver_id, status, created_at, updated_at)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,13 +9,13 @@ VALUES ('FREE', '무료 체험', '기본적인 서비스 탐색이 가능한 무
 -- 2. 사용자 데이터 (Users)
 -- 비밀번호: 'test1234' (BCrypt 암호화)
 -- 멤버십 ID 1번(FREE)을 기본 할당한다고 가정
-INSERT INTO users (email, password, nickname, signup_ip, role_type, is_social, is_lock, is_online, membership_id, created_at, updated_at)
-VALUES ('test@test.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', 'test', '127.0.0.1', 'USER', false, false, false, 1,  NOW(), NOW()),
-       ('kim@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '김철수', '127.0.0.2', 'USER', false, false, false, 1,  NOW(), NOW()),
-       ('lee@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '이영희', '127.0.0.3', 'USER', false, false, false, 1,  NOW(), NOW()),
-       ('park@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '박민수', '127.0.0.4', 'USER', false, false, false, 1,  NOW(), NOW()),
-       ('choi@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '최지은', '127.0.0.5', 'USER', false, false, false, 1,  NOW(), NOW()),
-       ('jung@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '정우성', '127.0.0.6', 'USER', false, false, false, 1,  NOW(), NOW());
+INSERT INTO users (email, password, nickname, signup_ip, role_type, is_social, is_lock, is_online, membership_id, last_notification_read_at, created_at, updated_at)
+VALUES ('test@test.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', 'test', '127.0.0.1', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
+       ('kim@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '김철수', '127.0.0.2', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
+       ('lee@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '이영희', '127.0.0.3', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
+       ('park@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '박민수', '127.0.0.4', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
+       ('choi@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '최지은', '127.0.0.5', 'USER', false, false, false, 1,  NOW(), NOW(), NOW()),
+       ('jung@joinflex.com', '$2a$10$hpAUduYxqdeK8L9Ft0Ud7.6Mf89EhSSiyrnuNeBjynJrq64sNZ5Hq', '정우성', '127.0.0.6', 'USER', false, false, false, 1,  NOW(), NOW(), NOW());
 
 -- 3. 친구 요청 (Friend Requests)
 INSERT INTO friend_requests (sender_id, receiver_id, status, created_at, updated_at)


### PR DESCRIPTION
## 구현한 내용
알림 일괄 읽음 처리를 구현하였습니다.
- User엔티티에 last_notification_read_at 필드를 추가하여, 사용자의 모든 알림 읽은 시간 이후로 보내진 notification만을 필터링하여 사용자에게 SSE 이벤트 메시지로 보내집니다.
- /notifications/last-read-at 엔드포인트를 추가하였습니다. 사용자의 모든 알림 읽은 시간을 최신 시간으로 변경합니다.

## [특이사항]

data.sql에 last_notification_read_at필드와 값 추가 하였습니다.