### PR TITLE
Fix: UserResponse 받아오지 못하던 문제 수정

### DIFF
--- a/src/main/java/com/sesac/joinflex/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sesac/joinflex/domain/chat/controller/ChatController.java
@@ -4,12 +4,13 @@ import com.sesac.joinflex.domain.chat.dto.request.ChatMessageRequest;
 import com.sesac.joinflex.domain.chat.dto.response.ChatMessageResponse;
 import com.sesac.joinflex.domain.chat.service.ChatService;
 import com.sesac.joinflex.domain.user.dto.response.UserResponse;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -20,15 +21,19 @@ public class ChatController {
 
     @MessageMapping("/party/{partyId}/enter")
     @SendTo("/sub/party/{partyId}")
-    public ChatMessageResponse enterUser(@DestinationVariable Long partyId,
-        @AuthenticationPrincipal UserResponse userResponse) {
+    public ChatMessageResponse enterUser(@DestinationVariable Long partyId, Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        UserResponse userResponse = (UserResponse) authentication.getPrincipal();
         return chatService.createEnterMessage(partyId, userResponse);
     }
 
     @MessageMapping("/party/{partyId}/talk")
     @SendTo("/sub/party/{partyId}")
     public ChatMessageResponse talkUser(@DestinationVariable Long partyId, @Payload
-    ChatMessageRequest request, @AuthenticationPrincipal UserResponse userResponse) {
+    ChatMessageRequest request, Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        UserResponse userResponse = (UserResponse) authentication.getPrincipal();
+        System.out.println(userResponse.getNickName());
         return chatService.createTalkMessage(partyId, userResponse, request.message());
     }
 


### PR DESCRIPTION
## 작업 내용
* 소켓 연결 및 메시지 발송 시 User의 닉네임이 null인 문제 발생
* 기존 `@AuthenticationPrincipal UserResponse userResponse` -> `Principal principal`로 변경 후 직접 꺼내는 걸로 변경