### PR TITLE
feat: 친구 및 파티 알림에 추적 메시지 추가

### DIFF
--- a/src/main/java/com/sesac/joinflex/domain/friend/service/FriendRequestService.java
+++ b/src/main/java/com/sesac/joinflex/domain/friend/service/FriendRequestService.java
@@ -49,7 +49,7 @@ public class FriendRequestService {
 
         sendNotification(receiverId,
             NotificationMessageTemplate.friendRequest(sender.getNickname()),
-            NotificationType.FRIEND_REQUEST);
+            NotificationType.FRIEND_REQUEST, senderId, receiverId);
 
         return FriendRequestResponse.from(saved);
     }
@@ -64,7 +64,7 @@ public class FriendRequestService {
 
         sendNotification(request.getSender().getId(),
             NotificationMessageTemplate.friendAccept(request.getReceiver().getNickname()),
-            NotificationType.FRIEND_ACCEPT);
+            NotificationType.FRIEND_ACCEPT, request.getReceiver().getId(), request.getSender().getId());
 
         return FriendRequestResponse.from(request);
     }
@@ -77,7 +77,7 @@ public class FriendRequestService {
 
         sendNotification(request.getSender().getId(),
             NotificationMessageTemplate.eventReject(),
-            NotificationType.EVENT_REJECT);
+            NotificationType.EVENT_REJECT, request.getReceiver().getId(), request.getSender().getId());
 
         friendRequestRepository.delete(request);
     }
@@ -90,7 +90,7 @@ public class FriendRequestService {
 
         sendNotification(request.getReceiver().getId(),
                 NotificationMessageTemplate.eventCancel(),
-                NotificationType.EVENT_CANCEL);
+                NotificationType.EVENT_CANCEL, request.getSender().getId(), request.getReceiver().getId());
 
         friendRequestRepository.delete(request);
     }
@@ -105,7 +105,7 @@ public class FriendRequestService {
 
         sendNotification(target.getId(),
                 NotificationMessageTemplate.eventDelete(),
-                NotificationType.EVENT_DELETE);
+                NotificationType.EVENT_DELETE, userId, target.getId());
 
         friendRequestRepository.delete(request);
     }
@@ -175,9 +175,10 @@ public class FriendRequestService {
         }
     }
 
-    private void sendNotification(Long userId, String message, NotificationType type) {
+    private void sendNotification(Long userId, String message, NotificationType type,
+                                   Long senderId, Long receiverId) {
         try {
-            notificationService.sendAndSave(userId, message, type);
+            notificationService.sendAndSave(userId, message, type, senderId, receiverId, null);
         } catch (Exception e) {
             switch (type) {
                 // SSE 메시지 관련 예외 처리가 필요할 때 추가할 예정

--- a/src/main/java/com/sesac/joinflex/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/dto/response/NotificationResponse.java
@@ -14,10 +14,19 @@ public class NotificationResponse {
     private String message;
     private LocalDateTime createdAt;
     private NotificationType notificationType;
+    private Long senderId;
+    private Long receiverId;
+    private String eventId;
 
     public static NotificationResponse from(Notification notification) {
         return NotificationResponse.builder()
             .id(notification.getId())
-            .message(notification.getMessage()).notificationType(notification.getNotificationType()).createdAt(notification.getCreatedAt()).build();
+            .message(notification.getMessage())
+            .notificationType(notification.getNotificationType())
+            .createdAt(notification.getCreatedAt())
+            .senderId(notification.getSenderId())
+            .receiverId(notification.getReceiverId())
+            .eventId(notification.getEventId())
+            .build();
     }
 }

--- a/src/main/java/com/sesac/joinflex/domain/notification/entity/Notification.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/entity/Notification.java
@@ -5,7 +5,6 @@ import com.sesac.joinflex.domain.user.entity.User;
 import com.sesac.joinflex.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,13 +29,24 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private NotificationType notificationType;
 
-    private Notification(User user, String message, NotificationType notificationType) {
+    private Long senderId;
+
+    private Long receiverId;
+
+    private String eventId;
+
+    private Notification(User user, String message, NotificationType notificationType,
+                         Long senderId, Long receiverId, String eventId) {
         this.user = user;
         this.message = message;
         this.notificationType = notificationType;
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.eventId = eventId;
     }
 
-    public static Notification create(User user, String message, NotificationType notificationType) {
-        return new Notification(user, message, notificationType);
+    public static Notification create(User user, String message, NotificationType notificationType,
+                                      Long senderId, Long receiverId, String eventId) {
+        return new Notification(user, message, notificationType, senderId, receiverId, eventId);
     }
 }

--- a/src/main/java/com/sesac/joinflex/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sesac/joinflex/domain/notification/service/NotificationService.java
@@ -80,9 +80,11 @@ public class NotificationService {
         }
     }
 
-    public void sendAndSave(Long userId, String message, NotificationType notificationType) {
-        send(userId, NotificationResponse.from(
-            notificationRepository.save(Notification.create(getUser(userId), message, notificationType))));
+    public void sendAndSave(Long userId, String message, NotificationType notificationType,
+                            Long senderId, Long receiverId, String eventId) {
+        Notification saved = notificationRepository.save(
+            Notification.create(getUser(userId), message, notificationType, senderId, receiverId, eventId));
+        send(userId, NotificationResponse.from(saved));
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/sesac/joinflex/domain/party/service/PartyInviteService.java
+++ b/src/main/java/com/sesac/joinflex/domain/party/service/PartyInviteService.java
@@ -43,7 +43,8 @@ public class PartyInviteService {
             sendInviteEmail(guest, room);
             String notificationMessage = NotificationMessageTemplate.notification(
                 room.getHost().getNickname(), room.getRoomName(), guest.getNickname());
-            notificationService.sendAndSave(guest.getId(), notificationMessage, NotificationType.PARTY_INVITE);
+            notificationService.sendAndSave(guest.getId(), notificationMessage, NotificationType.PARTY_INVITE,
+                null, null, String.valueOf(room.getId()));
 
         }
     }


### PR DESCRIPTION
## [구현한 기능]

친구 및 파티 알림에 추적 메시지 추가


## [특이사항]
Notification 엔티티에 sender_id, receiver_id, event_id 컬럼 추가 되었습니다.


close #91 
