### PR TITLE
Feat: 동시성 처리

### DIFF
--- a/src/main/java/com/sesac/joinflix/domain/party/repository/PartyRoomRepository.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/repository/PartyRoomRepository.java
@@ -1,9 +1,12 @@
 package com.sesac.joinflix.domain.party.repository;
 
 import com.sesac.joinflix.domain.party.entity.PartyRoom;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -21,4 +24,14 @@ public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
             """
     )
     Slice<PartyRoom> findPartyRooms(@Param("cursorId") Long cursorId, Pageable pageable);
+
+    // 비관적 락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+                select p from PartyRoom p
+                where p.id = :partyId
+            """
+    )
+    Optional<PartyRoom> findByIdWithLock(@Param("partyId") Long partyId);
 }

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
@@ -76,7 +76,8 @@ public class PartyService {
     @Transactional
     public PartyRoomResponse joinParty(Long partyId, PartyJoinRequest request, Long userId) {
         // 파티방 존재 여부 검증
-        PartyRoom partyRoom = getPartyRoom(partyId);
+        PartyRoom partyRoom = partyRoomRepository.findByIdWithLock(partyId)
+            .orElseThrow(() -> new CustomException(ErrorCode.PARTY_NOT_FOUND));
 
         // 사용자 검증
         User user = getUser(userId);


### PR DESCRIPTION
## 작업 내용

* 비관적 락 적용 : 파티방 입장 시 발생하는 동시성 및 데드락 문제 해결

* 배타 락 설정으로 파티방 조회 시 트랜잭션 간 충돌 방지

## JMeter 테스트

* 배타 락 설정 전 데드락 발생
   * 401 응답 이유 : 데드락 예외를 잡는 핸들러가 없어서 예외 전파되어 인증 오류 처리됨
<img width="754" height="287" alt="image" src="https://github.com/user-attachments/assets/c3d1fd2d-0eb5-4b66-87eb-9b47a249c61b" />
<img width="754" height="287" alt="스크린샷 2026-02-16 오후 5 54 23" src="https://github.com/user-attachments/assets/dbfad6ea-df2f-4066-a4ab-e2125f939cd4" />

* 배타 락 설정 후 정상 처리
<img width="754" height="287" alt="스크린샷 2026-02-16 오후 5 58 22" src="https://github.com/user-attachments/assets/d82ef858-fa53-4a7c-b202-54e823dae0b3" />

