### PR TITLE
Feat:  영상 싱크 동기화

### DIFF
--- a/src/main/java/com/sesac/joinflix/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sesac/joinflix/domain/chat/controller/ChatController.java
@@ -70,6 +70,9 @@ public class ChatController {
         if (!partyService.canControlVideo(partyId, user.getId())) {
             return null;
         }
+
+        partyService.saveVideoStatus(partyId, request);
+
         return chatService.createSyncMessage(user, request);
     }
 

--- a/src/main/java/com/sesac/joinflix/domain/party/dto/response/PartyRoomResponse.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/dto/response/PartyRoomResponse.java
@@ -1,5 +1,8 @@
 package com.sesac.joinflix.domain.party.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sesac.joinflix.domain.party.entity.PartyRoom;
+
 public record PartyRoomResponse(
     Long id,
     String movieTitle,
@@ -7,7 +10,27 @@ public record PartyRoomResponse(
     Boolean isPublic,
     String roomName,
     String hostNickname,
-    Integer currentMemberCount
+    Integer currentMemberCount,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    VideoStatus videoStatus
 ) {
+
+    public static PartyRoomResponse of(PartyRoom partyRoom, VideoStatus videoStatus) {
+        return new PartyRoomResponse(
+            partyRoom.getId(), partyRoom.getMovie().getTitle(),
+            partyRoom.getMovie().getBackdrop(), partyRoom.getIsPublic(),
+            partyRoom.getRoomName(), partyRoom.getHost().getNickname(),
+            partyRoom.getCurrentMemberCount(), videoStatus
+        );
+    }
+
+    public static PartyRoomResponse of(PartyRoom partyRoom) {
+        return new PartyRoomResponse(
+            partyRoom.getId(), partyRoom.getMovie().getTitle(),
+            partyRoom.getMovie().getBackdrop(), partyRoom.getIsPublic(),
+            partyRoom.getRoomName(), partyRoom.getHost().getNickname(),
+            partyRoom.getCurrentMemberCount(), null
+        );
+    }
 
 }

--- a/src/main/java/com/sesac/joinflix/domain/party/dto/response/VideoStatus.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/dto/response/VideoStatus.java
@@ -1,0 +1,8 @@
+package com.sesac.joinflix.domain.party.dto.response;
+
+public record VideoStatus(
+    Double currentTime,
+    Boolean paused
+) {
+
+}

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
@@ -72,15 +72,7 @@ public class PartyService {
         Slice<PartyRoom> rooms = partyRoomRepository.findPartyRooms(
             cursorId == null ? Long.MAX_VALUE : cursorId, pageable);
 
-        return rooms.map(room -> new PartyRoomResponse(
-            room.getId(),
-            room.getMovie().getTitle(),
-            room.getMovie().getBackdrop(),
-            room.getIsPublic(),
-            room.getRoomName(),
-            room.getHost().getNickname(),
-            room.getCurrentMemberCount()
-        ));
+        return rooms.map(PartyRoomResponse::of);
     }
 
 
@@ -97,10 +89,7 @@ public class PartyService {
 
         processEntry(partyRoom, user, request);
 
-        return new PartyRoomResponse(partyRoom.getId(), partyRoom.getMovie().getTitle(),
-            partyRoom.getMovie().getBackdrop(), partyRoom.getIsPublic(),
-            partyRoom.getRoomName(), partyRoom.getHost().getNickname(),
-            partyRoom.getCurrentMemberCount());
+        return PartyRoomResponse.of(partyRoom);
     }
 
     @Transactional
@@ -174,10 +163,7 @@ public class PartyService {
 
     public PartyRoomResponse getPartyRoomResponse(Long partyId) {
         PartyRoom partyRoom = getPartyRoom(partyId);
-        return new PartyRoomResponse(partyRoom.getId(), partyRoom.getMovie().getTitle(),
-            partyRoom.getMovie().getBackdrop(), partyRoom.getIsPublic(),
-            partyRoom.getRoomName(), partyRoom.getHost().getNickname(),
-            partyRoom.getCurrentMemberCount());
+        return PartyRoomResponse.of(partyRoom);
     }
 
     public List<MemberResponse> getMembers(Long partyId, Long userId) {

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,7 +45,7 @@ public class PartyService {
     private final MovieRepository movieRepository;
     private final UserRepository userRepository;
     private final PartyInviteService partyInviteService;
-    private final RedisTemplate redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     @Transactional
     public Long createPartyRoom(PartyRoomRequest request, Long userId) {
@@ -207,9 +207,9 @@ public class PartyService {
     public void saveVideoStatus(Long partyId, VideoSyncRequest request) {
         String key = VIDEO_KEY_PREFIX + partyId + VIDEO_KEY_SUFFIX;
 
-        Map<String, Object> videoStatus = new HashMap<>();
-        videoStatus.put(REDIS_FIELD_CURRENT_TIME, request.currentTime().toString());
-        videoStatus.put(REDIS_FIELD_PAUSED, request.paused());
+        Map<String, String> videoStatus = new HashMap<>();
+        videoStatus.put(REDIS_FIELD_CURRENT_TIME, String.valueOf(request.currentTime()));
+        videoStatus.put(REDIS_FIELD_PAUSED, String.valueOf(request.paused()));
         videoStatus.put(REDIS_FIELD_UPDATED_AT, String.valueOf(System.currentTimeMillis()));
 
         redisTemplate.opsForHash().putAll(key, videoStatus);

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
@@ -1,6 +1,7 @@
 package com.sesac.joinflix.domain.party.service;
 
 import com.sesac.joinflix.domain.chat.dto.request.LeaveRequest;
+import com.sesac.joinflix.domain.chat.dto.request.VideoSyncRequest;
 import com.sesac.joinflix.domain.movie.entity.Movie;
 import com.sesac.joinflix.domain.movie.repository.MovieRepository;
 import com.sesac.joinflix.domain.party.dto.request.PartyJoinRequest;
@@ -17,11 +18,14 @@ import com.sesac.joinflix.domain.user.entity.User;
 import com.sesac.joinflix.domain.user.repository.UserRepository;
 import com.sesac.joinflix.global.exception.CustomException;
 import com.sesac.joinflix.global.exception.ErrorCode;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,11 +34,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PartyService {
 
+    private static final String VIDEO_KEY_PREFIX = "party:";
+    private static final String VIDEO_KEY_SUFFIX = ":video";
+    private static final String REDIS_FIELD_CURRENT_TIME = "currentTime";
+    private static final String REDIS_FIELD_PAUSED = "paused";
+    private static final String REDIS_FIELD_UPDATED_AT = "updatedAt";
+
     private final PartyRoomRepository partyRoomRepository;
     private final PartyMemberRepository partyMemberRepository;
     private final MovieRepository movieRepository;
     private final UserRepository userRepository;
     private final PartyInviteService partyInviteService;
+    private final RedisTemplate redisTemplate;
 
     @Transactional
     public Long createPartyRoom(PartyRoomRequest request, Long userId) {
@@ -191,6 +202,19 @@ public class PartyService {
         }
 
         return !partyRoom.getHostControl() || member.isHost();
+    }
+
+    public void saveVideoStatus(Long partyId, VideoSyncRequest request) {
+        String key = VIDEO_KEY_PREFIX + partyId + VIDEO_KEY_SUFFIX;
+
+        Map<String, Object> videoStatus = new HashMap<>();
+        videoStatus.put(REDIS_FIELD_CURRENT_TIME, request.currentTime().toString());
+        videoStatus.put(REDIS_FIELD_PAUSED, request.paused());
+        videoStatus.put(REDIS_FIELD_UPDATED_AT, String.valueOf(System.currentTimeMillis()));
+
+        redisTemplate.opsForHash().putAll(key, videoStatus);
+
+        // Todo redis 만료 시간
     }
 
     private PartyRoom getPartyRoom(Long partyId) {

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
@@ -8,6 +8,7 @@ import com.sesac.joinflix.domain.party.dto.request.PartyJoinRequest;
 import com.sesac.joinflix.domain.party.dto.request.PartyRoomRequest;
 import com.sesac.joinflix.domain.party.dto.response.MemberResponse;
 import com.sesac.joinflix.domain.party.dto.response.PartyRoomResponse;
+import com.sesac.joinflix.domain.party.dto.response.VideoStatus;
 import com.sesac.joinflix.domain.party.entity.MemberRole;
 import com.sesac.joinflix.domain.party.entity.MemberStatus;
 import com.sesac.joinflix.domain.party.entity.PartyMember;
@@ -89,7 +90,9 @@ public class PartyService {
 
         processEntry(partyRoom, user, request);
 
-        return PartyRoomResponse.of(partyRoom);
+        VideoStatus videoStatus = getCalculatedVideoStatus(partyId);
+
+        return PartyRoomResponse.of(partyRoom, videoStatus);
     }
 
     @Transactional
@@ -252,5 +255,28 @@ public class PartyService {
     private void addMember(PartyRoom partyRoom, User user, MemberRole role) {
         partyMemberRepository.save(PartyMember.create(partyRoom, user, role));
         partyRoom.addMember();
+    }
+
+    private VideoStatus getCalculatedVideoStatus(Long partyId) {
+        String key = VIDEO_KEY_PREFIX + partyId + VIDEO_KEY_SUFFIX;
+
+        Map<String, String> status = redisTemplate.<String, String>opsForHash().entries(key);
+
+        if (status.isEmpty()) {
+            return new VideoStatus(0.0, true); // 0초, 일시정지 상태
+        }
+
+        double savedTime = Double.parseDouble(status.get(REDIS_FIELD_CURRENT_TIME));
+        boolean isPaused = Boolean.parseBoolean(status.get(REDIS_FIELD_PAUSED));
+        long updatedAt = Long.parseLong(status.get(REDIS_FIELD_UPDATED_AT));
+
+        double finalTime = savedTime;
+        if (!isPaused) {
+            // 재생 중이면 현재시간 - 저장 시점 시간
+            double diff = (System.currentTimeMillis() - updatedAt) / 1000.0;
+            finalTime += diff;
+        }
+
+        return new VideoStatus(finalTime, isPaused);
     }
 }


### PR DESCRIPTION
## 작업 내용
* 영상 조작 이벤트 발생 시 레디스에 파티별 영상 상태(재생 시간, 일시정지 여부, 저장 시간) 저장
* 파티방 입장 시 현재 시간과 마지막 저장 시간 차이를 계산(`최종 시간 = 저장된 시간 + (현재 시간 - 저장 시점)`)한 시간을 응답
* PartyRoomResponse 내 VideoStatus 필드 추가 및 정적 팩토리 메서드 적용

## 포스트맨 결과
* 일시정지 상태 (영상 시작 전)
<img width="677" height="341" alt="스크린샷 2026-02-17 오후 5 39 36" src="https://github.com/user-attachments/assets/e8e3e6eb-1f48-4e70-b622-24ae45c2bb85" />

* 일시정지 상태 (영상 재생 후 일시정지)
<img width="677" height="341" alt="스크린샷 2026-02-17 오후 5 44 03" src="https://github.com/user-attachments/assets/d48a0cd5-2ec5-4a14-94a6-ff40d2c1c6bf" />

* 재생 상태 (영상 재생 중)
<img width="677" height="341" alt="스크린샷 2026-02-17 오후 5 38 26" src="https://github.com/user-attachments/assets/914dd81e-7a65-447d-bd94-d98788cd4bb2" />
