### PR TITLE
Feat 파티 예약

### DIFF
--- a/src/main/java/com/sesac/joinflix/domain/party/dto/request/PartyRoomRequest.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/dto/request/PartyRoomRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record PartyRoomRequest(
@@ -28,7 +29,9 @@ public record PartyRoomRequest(
     @Pattern(regexp = "\\d{4}")
     String passCode,
 
-    List<Long> invitedUserIds
+    List<Long> invitedUserIds,
+
+    LocalDateTime scheduledAt
 ) {
 
     public PartyRoomRequest {
@@ -42,5 +45,20 @@ public record PartyRoomRequest(
         }
 
         return passCode != null && !passCode.isBlank();
+    }
+
+    @AssertTrue(message = "예약 시간은 30분 단위의 미래 시간이어야 합니다.")
+    private boolean isScheduledAtValid() {
+        if (scheduledAt == null) {
+            return true;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneWeekLater = now.plusWeeks(1);
+
+        return scheduledAt.isAfter(now) && scheduledAt.isBefore(oneWeekLater)
+            && scheduledAt.getMinute() % 30 == 0
+            && scheduledAt.getSecond() == 0
+            && scheduledAt.getNano() == 0;
     }
 }

--- a/src/main/java/com/sesac/joinflix/domain/party/dto/request/PartyRoomRequest.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/dto/request/PartyRoomRequest.java
@@ -47,7 +47,7 @@ public record PartyRoomRequest(
         return passCode != null && !passCode.isBlank();
     }
 
-    @AssertTrue(message = "예약 시간은 30분 단위의 미래 시간이어야 합니다.")
+    @AssertTrue(message = "예약 시간은 현재 시간 이후 1주일 이내의 30분 단위 시간이어야 합니다.")
     private boolean isScheduledAtValid() {
         if (scheduledAt == null) {
             return true;

--- a/src/main/java/com/sesac/joinflix/domain/party/entity/PartyRoom.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/entity/PartyRoom.java
@@ -116,6 +116,10 @@ public class PartyRoom extends BaseEntity {
         return this.passCode.equals(passCode);
     }
 
+    public void activate() {
+        this.status = PartyStatus.ACTIVE;
+    }
+
     private boolean isFull() {
         return currentMemberCount >= maxCount;
     }

--- a/src/main/java/com/sesac/joinflix/domain/party/entity/PartyRoom.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/entity/PartyRoom.java
@@ -7,6 +7,8 @@ import com.sesac.joinflix.global.exception.CustomException;
 import com.sesac.joinflix.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -52,8 +55,14 @@ public class PartyRoom extends BaseEntity {
 
     private Integer currentMemberCount;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PartyStatus status;
+
+    private LocalDateTime scheduledAt;
+
     private PartyRoom(String roomName, User host, Movie movie, Boolean isPublic,
-        Boolean hostControl, String passCode) {
+        Boolean hostControl, String passCode, PartyStatus status, LocalDateTime scheduledAt) {
         this.roomName = roomName;
         this.host = host;
         this.movie = movie;
@@ -62,13 +71,20 @@ public class PartyRoom extends BaseEntity {
         this.passCode = passCode;
         this.currentMemberCount = 0;
         this.maxCount = 4;
+        this.status = status;
+        this.scheduledAt = scheduledAt;
     }
 
-    public static PartyRoom create(String roomName, User host, Movie movie, Boolean isPublic, Boolean hostControl, String passCode) {
+    public static PartyRoom create(String roomName, User host, Movie movie, Boolean isPublic,
+        Boolean hostControl, String passCode, LocalDateTime scheduledAt) {
+
+        PartyStatus partyStatus = scheduledAt == null ? PartyStatus.ACTIVE : PartyStatus.SCHEDULED;
+
         if (isPublic) {
-            return new PartyRoom(roomName, host, movie, true, true, null);
+            return new PartyRoom(roomName, host, movie, true, true, null, partyStatus, scheduledAt);
         } else {
-            return new PartyRoom(roomName, host, movie, false, hostControl, passCode);
+            return new PartyRoom(roomName, host, movie, false, hostControl, passCode, partyStatus,
+                scheduledAt);
         }
     }
 

--- a/src/main/java/com/sesac/joinflix/domain/party/entity/PartyStatus.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/entity/PartyStatus.java
@@ -1,0 +1,6 @@
+package com.sesac.joinflix.domain.party.entity;
+
+public enum PartyStatus {
+    SCHEDULED,
+    ACTIVE
+}

--- a/src/main/java/com/sesac/joinflix/domain/party/repository/PartyInviteRepository.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/repository/PartyInviteRepository.java
@@ -3,6 +3,7 @@ package com.sesac.joinflix.domain.party.repository;
 import com.sesac.joinflix.domain.party.entity.PartyInvite;
 import com.sesac.joinflix.domain.party.entity.PartyRoom;
 import com.sesac.joinflix.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface PartyInviteRepository extends JpaRepository<PartyInvite, Long>,
     Optional<PartyInvite> findByPartyRoomAndGuest(PartyRoom partyRoom, User user);
 
     void deleteAllByPartyRoom(PartyRoom partyRoom);
+
+    List<PartyInvite> findByPartyRoom(PartyRoom room);
 }

--- a/src/main/java/com/sesac/joinflix/domain/party/repository/PartyRoomRepository.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/repository/PartyRoomRepository.java
@@ -1,7 +1,10 @@
 package com.sesac.joinflix.domain.party.repository;
 
 import com.sesac.joinflix.domain.party.entity.PartyRoom;
+import com.sesac.joinflix.domain.party.entity.PartyStatus;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -34,4 +37,7 @@ public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
             """
     )
     Optional<PartyRoom> findByIdWithLock(@Param("partyId") Long partyId);
+
+    List<PartyRoom> findByStatusAndScheduledAtLessThanEqual(PartyStatus status,
+        LocalDateTime dateTime);
 }

--- a/src/main/java/com/sesac/joinflix/domain/party/scheduler/PartyScheduler.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/scheduler/PartyScheduler.java
@@ -1,0 +1,38 @@
+package com.sesac.joinflix.domain.party.scheduler;
+
+import com.sesac.joinflix.domain.party.entity.PartyRoom;
+import com.sesac.joinflix.domain.party.entity.PartyStatus;
+import com.sesac.joinflix.domain.party.repository.PartyRoomRepository;
+import com.sesac.joinflix.domain.party.service.PartyInviteService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PartyScheduler {
+
+    private final PartyRoomRepository partyRoomRepository;
+    private final PartyInviteService partyInviteService;
+
+    @Scheduled(cron = "0 0,30 * * * *")  // 매시 정각, 30분마다
+    @Transactional
+    public void activateScheduledParties() {
+        LocalDateTime now = LocalDateTime.now().plusMinutes(1);
+
+        List<PartyRoom> partyRooms = partyRoomRepository.findByStatusAndScheduledAtLessThanEqual(
+            PartyStatus.SCHEDULED, now);
+
+        if (partyRooms.isEmpty()) {
+            return;
+        }
+
+        for (PartyRoom room : partyRooms) {
+            room.activate();
+            partyInviteService.sendInviteNotifications(room);
+        }
+    }
+}

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyInviteService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyInviteService.java
@@ -31,7 +31,18 @@ public class PartyInviteService {
     @Value("${app.domain-url}")
     private String domainUrl;
 
+    @Transactional
     public void inviteUsers(PartyRoom room, User host, List<Long> userIds) {
+        saveInvites(room, host, userIds);
+        sendInviteNotifications(room);
+    }
+
+    @Transactional
+    public void saveInvites(PartyRoom room, User host, List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return;
+        }
+
         List<User> guests = userRepository.findFriendsByHostAndIds(host, userIds);
 
         if (guests.size() != userIds.size()) {
@@ -43,8 +54,14 @@ public class PartyInviteService {
             .toList();
 
         partyInviteRepository.saveAll(invites);
+    }
 
-        for (User guest : guests) {
+    public void sendInviteNotifications(PartyRoom room) {
+        List<PartyInvite> invites = partyInviteRepository.findByPartyRoom(room);
+
+        for (PartyInvite invite : invites) {
+            User guest = invite.getGuest();
+
             // 파티 초대 이벤트 발행
             eventPublisher.publishEvent(
                 new PartyInviteEvent(guest.getEmail(), room.getHost().getNickname(),
@@ -55,7 +72,6 @@ public class PartyInviteService {
             notificationService.sendAndSave(guest.getId(), notificationMessage,
                 NotificationType.PARTY_INVITE,
                 null, null, room.getId());
-
         }
     }
 

--- a/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
+++ b/src/main/java/com/sesac/joinflix/domain/party/service/PartyService.java
@@ -58,11 +58,14 @@ public class PartyService {
 
         PartyRoom savedRoom = partyRoomRepository.save(
             PartyRoom.create(request.roomName(), host, movie, request.isPublic(),
-                request.hostControl(),
-                request.passCode()));
+                request.hostControl(), request.passCode(), request.scheduledAt()));
 
-        // 친구 초대
-        partyInviteService.inviteUsers(savedRoom, host, request.invitedUserIds());
+        if (request.scheduledAt() == null) {
+            // 친구 초대
+            partyInviteService.inviteUsers(savedRoom, host, request.invitedUserIds());
+        } else {
+            partyInviteService.saveInvites(savedRoom, host, request.invitedUserIds());
+        }
 
         return savedRoom.getId();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -115,15 +115,15 @@ VALUES
 
 
 -- 5. 파티방 (Party Rooms)
-INSERT INTO party_rooms (host_id, movie_id, room_name, is_public, host_control, max_count, current_member_count, created_at, updated_at)
-VALUES (4, 4, '재밌겠다', true, true, 4, 2, NOW(), NOW()), -- ID 4: 박민수 방
-       (2, 5, '리메이크 기념', false, true, 4, 2, NOW(), NOW()), -- ID 2: 이영희 방
-       (2, 7, '키튼', true, true, 4, 2, NOW(), NOW()), -- ID 2: 이영희 방
-        (1, 8, '귀여워', false, true, 4, 2, NOW(), NOW()), -- ID 1: 김철수 방
-       (1, 3, '징그러워', true, true, 4, 2, NOW(), NOW()), -- ID 1: 김철수 방
-       (2, 2, '오데사', false, true, 4, 2, NOW(), NOW()), -- ID 2: 이영희 방
-       (3, 6, '흥미진진', true, true, 4, 2, NOW(), NOW()), -- ID 3: 정우성 방
-       (5, 1, '같이 영화봐요', true, true, 4, 2,NOW(), NOW()); -- ID 5:  최지은 방
+INSERT INTO party_rooms (host_id, movie_id, room_name, is_public, host_control, max_count, current_member_count, status, scheduled_at, created_at, updated_at)
+VALUES (4, 4, '재밌겠다', true, true, 4, 2,'ACTIVE', NOW(), NOW(), NOW()), -- ID 4: 박민수 방
+       (2, 5, '리메이크 기념', false, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()), -- ID 2: 이영희 방
+       (2, 7, '키튼', true, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()), -- ID 2: 이영희 방
+        (1, 8, '귀여워', false, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()), -- ID 1: 김철수 방
+       (1, 3, '징그러워', true, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()), -- ID 1: 김철수 방
+       (2, 2, '오데사', false, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()), -- ID 2: 이영희 방
+       (3, 6, '흥미진진', true, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()), -- ID 3: 정우성 방
+       (5, 1, '같이 영화봐요', true, true, 4, 2, 'ACTIVE', NOW(), NOW(), NOW()); -- ID 5:  최지은 방
 
 -- 6. 파티 초대 (Party Invites)
 INSERT INTO party_invites (party_room_id, guest_id, created_at, updated_at)


### PR DESCRIPTION
## 작업 내용
* 파티 생성 시 예약 가능하도록 기능 추가
   *  예약 단위는 30분
   * 예약 가능한 기간은 1주일 이내 (임의로 설정한 거라 추후 수정 필요하다면 수정 가능)
* 파티 예약 요청 시 `SCHEDULED` 상태로  생성 후 예약 시간에 맞춰서 스케줄러를 통해 `ACTIVE` 처리
   * 친구 초대 알림 발송 또한 예약 시간에 맞춰서 전송


## 테스트
```json
// 공개파티 즉시 생성
{
    "movieId": 1,
    "roomName": "같이 봐요",
    "isPublic": true,
    "hostControl": true,
    "passCode": null,
    "invitedUserIds": [],
    "scheduledAt": null
}

// 공개파티 예약
{
    "movieId": 1,
    "roomName": "2시 30분 시작",
    "isPublic": true,
    "hostControl": true,
    "passCode": null,
    "invitedUserIds": [],
    "scheduledAt": "2026-02-22T14:30:00"
}

// 비공개파티 예약 (친구 초대)
{
    "movieId": 1,
    "roomName": "친구들이랑 예약!!",
    "isPublic": false,
    "hostControl": false,
    "passCode": "1234",
    "invitedUserIds": [34],
    "scheduledAt": "2026-02-22T18:00:00"
}
```

* 비공개 예약 파티 예약 시간에 맞춰서 친구 초대 알림 발송되는 것과 status 변경되는 것 확인
<img width="402" height="167" alt="스크린샷 2026-02-22 오후 6 00 59" src="https://github.com/user-attachments/assets/d5fed484-ecc9-4878-a85b-f76254b45089" />
<img width="233" height="31" alt="image" src="https://github.com/user-attachments/assets/53466abc-473d-49b4-ac37-21299721183a" />
